### PR TITLE
[2주차] 김동비/[feat] 공통 컴포넌트 및 홈페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vite-tsconfig-paths": "^6.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2386,6 +2387,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3539,6 +3547,27 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3722,6 +3751,21 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,10 @@
 // src/App.tsx
-import { Outlet } from 'react-router-dom'
+import { RouterProvider } from 'react-router-dom';
+import { router } from '@/router/Router';
 
 function App() {
-  return (
-    <div className="app-layout">
-      {/* 상단바(Nav)*/}
-      
-      <main>
-        <Outlet /> {/* Home.tsx 내용 */}
-      </main>
 
-      {/* 푸터(Footer)*/}
-    </div>
-  )
+  return <RouterProvider router={router} />;
 }
 
-export default App
+export default App;

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/utils/cn';
+
+interface AvatarProps {
+  src?: string;
+  alt?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export const Avatar = ({ src, alt = "user profile", size = "md", className }: AvatarProps) => {
+  const sizeStyles = {
+    sm: "h-8 w-8",
+    md: "h-10 w-10",
+    lg: "h-12 w-12",
+  };
+
+  return (
+    <div className={cn("relative flex-shrink-0 overflow-hidden rounded-full bg-gray-200", sizeStyles[size], className)}>
+      {src ? (
+        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-gray-400">
+          <svg fill="currentColor" viewBox="0 0 24 24" className="h-2/3 w-2/3"><path d="M24 20.993V24H0v-2.996A14.977 14.977 0 0112.004 15c4.904 0 9.26 2.354 11.996 5.993zM16.002 8.999a4 4 0 11-8 0 4 4 0 018 0z" /></svg>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,56 @@
+import { type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'outline';
+  size?: 'sm' | 'md' | 'lg';
+  isLoading?: boolean;
+  children: ReactNode;
+}
+
+export const Button = ({
+  variant = 'primary',
+  size = 'md',
+  isLoading,
+  className,
+  children,
+  disabled,
+  ...props
+}: ButtonProps) => {
+  
+  // 기본 스타일
+  const baseStyles = "inline-flex items-center justify-center rounded-md font-medium transition-all focus:outline-none active:scale-95 disabled:opacity-50 disabled:pointer-events-none";
+
+  // 변형(Variant) 스타일
+  const variants = {
+    primary: "bg-blue-600 text-white hover:bg-blue-700",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+    danger: "bg-red-500 text-white hover:bg-red-600",
+    outline: "border border-gray-300 bg-transparent hover:bg-gray-50 text-gray-700",
+  };
+
+  // 사이즈 스타일
+  const sizes = {
+    sm: "h-8 px-3 text-xs",
+    md: "h-10 px-4 text-sm",
+    lg: "h-12 px-6 text-base",
+  };
+
+  return (
+    <button
+      className={cn(
+        baseStyles,
+        variants[variant],
+        sizes[size],
+        className // 외부에서 추가로 넣는 margin 등을 위해 마지막에 배치
+      )}
+      disabled={disabled || isLoading}
+      {...props}
+    >
+      {isLoading ? (
+        <span className="mr-2 h-4 w-4 animate-spin border-2 border-current border-t-transparent rounded-full" />
+      ) : null}
+      {children}
+    </button>
+  );
+};

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,56 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import { cn } from '@/utils/cn';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string; 
+}
+
+// forwardRef를 사용하여 부모(React Hook Form 등)에서 input 요소에 직접 접근
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, className, id, ...props }, ref) => {
+    const isError = Boolean(error);
+
+    return (
+      <div className="flex flex-col gap-1.5 w-full">
+        {/* 라벨 영역 (접근성을 위해 htmlFor와 id 연결) */}
+        {label && (
+          <label 
+            htmlFor={id} 
+            className="text-sm font-medium text-gray-700 ml-1"
+          >
+            {label}
+          </label>
+        )}
+
+        {/* 입력창 영역 */}
+        <input
+          ref={ref}
+          id={id}
+          className={cn(
+            // 기본 스타일
+            "w-full px-4 py-2.5 rounded-lg border bg-white transition-all outline-none text-sm",
+            "placeholder:text-gray-400 disabled:bg-gray-50 disabled:text-gray-500",
+            
+            // 상태별 스타일 분기 (cn 활용)
+            isError 
+              ? "border-red-500 focus:ring-2 focus:ring-red-100" // 에러 발생 시
+              : "border-gray-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-100", // 정상 시
+            
+            className // 외부 커스텀 스타일
+          )}
+          {...props}
+        />
+
+        {/* 에러 메시지 영역 (상태에 따른 UI 피드백 요구사항) */}
+        {isError && (
+          <p className="text-xs text-red-500 ml-1 mt-0.5 animate-in fade-in slide-in-from-top-1">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input'; // forwardRef 사용 시 디버깅을 위해 이름

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,54 @@
+import { type ReactNode, useEffect } from 'react';
+import { Button } from './Button';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+export const Modal = ({ isOpen, onClose, title, children }: ModalProps) => {
+  // 모달이 열릴 때 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => { document.body.style.overflow = 'unset'; };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      {/* 배경 오버레이 */}
+      <div 
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200" 
+        onClick={onClose} 
+      />
+      
+      {/* 모달 콘텐츠 */}
+      <div className="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl animate-in zoom-in-95 duration-200">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        <div className="mb-6 text-gray-600">
+          {children}
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose}>취소</Button>
+          <Button onClick={onClose}>확인</Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from '@/utils/cn';
+
+export const Skeleton = ({ className }: { className?: string }) => {
+  return (
+    <div className={cn("animate-pulse rounded-md bg-gray-200", className)} />
+  );
+};

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/utils/cn';
+
+interface ToastProps {
+  message: string;
+  isVisible: boolean;
+}
+
+export const Toast = ({ message, isVisible }: ToastProps) => {
+  return (
+    <div 
+      className={cn(
+        "fixed bottom-8 left-1/2 -translate-x-1/2 z-[110] px-6 py-3 rounded-full bg-gray-900 text-white text-sm font-medium shadow-lg transition-all duration-300",
+        isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0 pointer-events-none"
+      )}
+    >
+      {message}
+    </div>
+  );
+};

--- a/src/components/domain/PostCard.tsx
+++ b/src/components/domain/PostCard.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+
+interface PostCardProps {
+  id: number;
+  thumbnail: string;
+  title: string;
+  excerpt: string;
+  author: string;
+  date: string;
+}
+
+export const PostCard = ({ id, thumbnail, title, excerpt, author, date }: PostCardProps) => {
+  return (
+    // 시맨틱 태그 article 사용 및 그룹 호버 효과
+    <article className="group overflow-hidden rounded-xl border border-gray-200 bg-white transition-all hover:-translate-y-1 hover:shadow-lg">
+      <Link to={`/post/${id}`}>
+        {/* 썸네일 영역 (이미지 최적화: aspect-ratio로 Layout Shift 방지) */}
+        <div className="aspect-[16/9] w-full overflow-hidden bg-gray-100">
+          <img 
+            src={thumbnail} 
+            alt={`${title} 썸네일`} 
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" 
+            loading="lazy" // 이미지 Lazy 로딩 적용
+          />
+        </div>
+        
+        {/* 텍스트 컨텐츠 영역 */}
+        <div className="p-5">
+          <h3 className="mb-2 line-clamp-2 text-lg font-bold text-gray-900 group-hover:text-blue-600">
+            {title}
+          </h3>
+          <p className="mb-4 line-clamp-3 text-sm text-gray-600">
+            {excerpt}
+          </p>
+          
+          {/* 하단 메타 정보 (작성자, 날짜) */}
+          <div className="flex items-center justify-between text-xs text-gray-400">
+            <span className="font-medium text-gray-500">{author}</span>
+            <span>{date}</span>
+          </div>
+        </div>
+      </Link>
+    </article>
+  );
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,69 @@
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/common/Button';
+import { cn } from '@/utils/cn';
+import { useState } from 'react';
+
+export const Header = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-white/80 backdrop-blur-md">
+      <div className="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-4 md:px-8">
+        
+        {/* 로고 */}
+        <Link to="/" className="text-xl font-bold tracking-tighter text-blue-600 transition-colors hover:text-blue-700">
+          Blog
+        </Link>
+
+        {/* 데스크탑 메뉴 (md 이상에서만 노출) */}
+        <nav className="hidden items-center gap-6 md:flex">
+          <Link to="/" className="text-sm font-medium text-gray-600 hover:text-blue-600">홈</Link>
+          <Link to="/write" className="text-sm font-medium text-gray-600 hover:text-blue-600">글쓰기</Link>
+          
+          <div className="ml-4 flex items-center gap-2">
+            <Link to="/login">
+              <Button variant="outline" size="sm">로그인</Button>
+            </Link>
+            <Link to="/signup">
+              <Button size="sm">회원가입</Button>
+            </Link>
+          </div>
+        </nav>
+
+        {/* 모바일 메뉴 버튼 (md 미만에서 노출) */}
+        <button 
+          className="inline-flex items-center justify-center rounded-md p-2 text-gray-600 hover:bg-gray-100 md:hidden"
+          onClick={() => setIsMenuOpen(!isMenuOpen)}
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {isMenuOpen ? (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* 모바일 드롭다운 메뉴 (애니메이션 효과) */}
+      <div className={cn(
+        "absolute left-0 top-16 w-full border-b bg-white p-4 transition-all duration-300 md:hidden",
+        isMenuOpen ? "translate-y-0 opacity-100" : "-translate-y-4 opacity-0 pointer-events-none"
+      )}>
+        <nav className="flex flex-col gap-4">
+          <Link to="/" className="text-base font-medium text-gray-600" onClick={() => setIsMenuOpen(false)}>홈</Link>
+          <Link to="/write" className="text-base font-medium text-gray-600" onClick={() => setIsMenuOpen(false)}>글쓰기</Link>
+          <hr />
+          <div className="flex flex-col gap-2">
+            <Link to="/login" onClick={() => setIsMenuOpen(false)}>
+              <Button variant="outline" className="w-full">로그인</Button>
+            </Link>
+            <Link to="/signup" onClick={() => setIsMenuOpen(false)}>
+              <Button className="w-full">회원가입</Button>
+            </Link>
+          </div>
+        </nav>
+      </div>
+    </header>
+  );
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,15 +17,33 @@ export const Header = () => {
 
         {/* 데스크탑 메뉴 (md 이상에서만 노출) */}
         <nav className="hidden items-center gap-6 md:flex">
-          <Link to="/" className="text-sm font-medium text-gray-600 hover:text-blue-600">홈</Link>
-          <Link to="/write" className="text-sm font-medium text-gray-600 hover:text-blue-600">글쓰기</Link>
+          {/* 검색바 */}
+          <div className="relative group mr-2">
+            <input 
+              type="text" 
+              placeholder="Search posts..." 
+              className="w-40 lg:w-48 rounded-full bg-gray-100 border-none py-1.5 pl-9 pr-4 text-xs transition-all duration-300 focus:w-64 focus:bg-white focus:ring-2 focus:ring-blue-500/10 outline-none"
+            />
+            <svg 
+              className="absolute left-3 top-2 h-4 w-4 text-gray-400 transition-colors group-focus-within:text-blue-500" 
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+
+
+          <Link to="/" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">홈</Link>
+          <Link to="/write" className="text-sm font-medium text-gray-600 hover:text-blue-600 transition-colors">글쓰기</Link>
           
-          <div className="ml-4 flex items-center gap-2">
+          <div className="ml-4 flex items-center gap-2 border-l pl-6 border-gray-100">
             <Link to="/login">
-              <Button variant="outline" size="sm">로그인</Button>
+              <Button variant="outline" size="sm" className="rounded-full px-5 border-gray-200">로그인</Button>
             </Link>
             <Link to="/signup">
-              <Button size="sm">회원가입</Button>
+              <Button size="sm" className="rounded-full px-5">회원가입</Button>
             </Link>
           </div>
         </nav>
@@ -50,16 +68,28 @@ export const Header = () => {
         "absolute left-0 top-16 w-full border-b bg-white p-4 transition-all duration-300 md:hidden",
         isMenuOpen ? "translate-y-0 opacity-100" : "-translate-y-4 opacity-0 pointer-events-none"
       )}>
-        <nav className="flex flex-col gap-4">
-          <Link to="/" className="text-base font-medium text-gray-600" onClick={() => setIsMenuOpen(false)}>홈</Link>
-          <Link to="/write" className="text-base font-medium text-gray-600" onClick={() => setIsMenuOpen(false)}>글쓰기</Link>
-          <hr />
-          <div className="flex flex-col gap-2">
+        {/* 검색바 */}
+        <div className="relative mb-6">
+          <input 
+            type="text" 
+            placeholder="Search..." 
+            className="w-full rounded-xl bg-gray-100 border-none py-3 pl-11 pr-4 text-sm outline-none"
+          />
+          <svg className="absolute left-4 top-3.5 h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </div>
+
+        <nav className="flex flex-col gap-5">
+          <Link to="/" className="text-ld font-bold text-gray-900" onClick={() => setIsMenuOpen(false)}>홈</Link>
+          <Link to="/write" className="text-lg font-bold text-gray-900" onClick={() => setIsMenuOpen(false)}>글쓰기</Link>
+          <hr className="border-gray-100" />
+          <div className="flex flex-col gap-3">
             <Link to="/login" onClick={() => setIsMenuOpen(false)}>
-              <Button variant="outline" className="w-full">로그인</Button>
+              <Button variant="outline" className="w-full rounded-xl py-6">로그인</Button>
             </Link>
             <Link to="/signup" onClick={() => setIsMenuOpen(false)}>
-              <Button className="w-full">회원가입</Button>
+              <Button className="w-full rounded-xl py-6">회원가입</Button>
             </Link>
           </div>
         </nav>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom';
+import { Header } from './Header'; 
+
+export const Layout = () => {
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      {/* 헤더 */}
+      <Header />
+      
+      {/* 본문 */}
+      <main className="mx-auto max-w-[1200px] px-4 py-8 md:px-8">
+        {/* Outlet */}
+        <Outlet />
+      </main>
+
+      {/* Footer */}
+    </div>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { RouterProvider } from 'react-router-dom' 
-import { router } from './router'
+import App from './App'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-
-    <RouterProvider router={router} />
+    <App />
   </StrictMode>,
 )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,126 +1,98 @@
-import { useState } from 'react'
-import reactLogo from '../assets/react.svg'
-import viteLogo from '../assets/vite.svg'
-import heroImg from '../assets/hero.png'
-import '../App.css'
-import { cn } from '../utils/cn';
+import { useState } from 'react';
+import { Modal } from '@/components/common/Modal';
+import { Toast } from '@/components/common/Toast';
+import { Button } from '@/components/common/Button';
+import { PostCard } from '@/components/domain/PostCard';
 
-function Home() { 
-  const [count, setCount] = useState(0)
+const Home = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+
+  // 더미 데이터
+  const dummyPosts = Array.from({ length: 6 }).map((_, i) => ({
+    id: i + 1,
+    title: i === 0 
+      ? "블로그 UI 레이아웃" 
+      : `ItoR 개발 블로그 포스팅 시리즈 ${i + 1}`,
+    excerpt: "공통 컴포넌트 설계/ Tailwind CSS를 활용한 반응형 그리드 시스템",
+    thumbnail: `https://picsum.photos/seed/${i + 123}/600/338`,
+    author: "김동비",
+    date: "2026.03.31"
+  }));
+
+  const handleToast = () => {
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 2000);
+  };
 
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/pages/Home.tsx</code> and save to test <code>HMR</code>
+    <div className="flex flex-col gap-12">
+      {/* --- Hero Section --- */}
+      <section className="relative overflow-hidden rounded-3xl bg-blue-600 px-6 py-16 text-white shadow-2xl md:px-12 md:py-20">
+        <div className="relative z-10 max-w-2xl">
+          <span className="inline-block rounded-full bg-blue-500/50 px-3 py-1 text-sm font-medium text-blue-100">
+            Leets 7th FE Project
+          </span>
+          <h1 className="mt-4 text-4xl font-extrabold tracking-tight md:text-6xl">
+            Idea to Reality, <br />
+            실현되는 기록의 가치
+          </h1>
+          <p className="mt-6 text-lg text-blue-100/90 md:text-xl">
+            2주차 미션을 통해 구축된 탄탄한 UI 파운데이션을 확인해보세요.
           </p>
+          <div className="mt-10 flex flex-wrap gap-4">
+            {/* 상호작용 테스트를 위해 버튼 클릭 시 모달이 뜨게 연결합니다 */}
+            <Button size="lg" className="bg-white text-blue-600 hover:bg-gray-100" onClick={() => setIsModalOpen(true)}>
+              미션 결과 확인하기
+            </Button>
+            <Button variant="outline" size="lg" className="border-white text-white hover:bg-white/10" onClick={handleToast}>
+              토스트 알림 띄우기
+            </Button>
+          </div>
         </div>
-        <button
-          className={cn("counter", count > 0 && "text-blue-500")}
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
+        <div className="absolute -right-20 -top-20 h-80 w-80 rounded-full bg-blue-500/30 blur-3xl" />
       </section>
 
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-                <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-                </a>
-            </li>
-
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-
-          </ul>
-
+      {/* --- Post Section --- */}
+      <section className="space-y-8">
+        <div className="flex items-end justify-between border-b pb-4">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 md:text-3xl">최신 게시글</h2>
+          </div>
         </div>
 
-        <div id="social">
+        <main className="grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+          {dummyPosts.map((post) => (
+            <PostCard key={post.id} {...post} />
+          ))}
+        </main>
+      </section>
 
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-
-          <ul>
-
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true" >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true" >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
+      {/* --- 하단 CTA --- */}
+      <section className="rounded-2xl bg-gray-100 py-12 text-center mb-10">
+        <h3 className="text-xl font-bold text-gray-800">뉴스레터 구독</h3>
+        <div className="mt-6 flex justify-center gap-2 px-4">
+          <input 
+            type="email" 
+            placeholder="이메일 주소를 입력하세요" 
+            className="w-full max-w-xs rounded-lg border border-gray-300 px-4 py-2"
+          />
+          <Button onClick={handleToast}>구독</Button>
         </div>
       </section>
 
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
-}
+      {/* --- 상호작용 컴포넌트들 (화면 어디서든 뜰 수 있게 배치) --- */}
+      <Modal 
+        isOpen={isModalOpen} 
+        onClose={() => setIsModalOpen(false)} 
+        title="2주차 미션"
+      >
+        <p>공통 컴포넌트 6종과 반응형 레이아웃 구현 </p>
+      </Modal>
 
-export default Home
+      <Toast message="성공적으로 알림이 전송되었습니다!" isVisible={showToast} />
+    </div>
+  );
+};
+
+export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,9 @@ const Home = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showToast, setShowToast] = useState(false);
 
+  //  음악 상태 더미 (UI 테스트용)
+  const [isPlaying, setIsPlaying] = useState(false);
+
   // 더미 데이터
   const dummyPosts = Array.from({ length: 6 }).map((_, i) => ({
     id: i + 1,
@@ -26,7 +29,8 @@ const Home = () => {
   };
 
   return (
-    <div className="flex flex-col gap-12">
+    <div className="flex flex-col gap-24 pb-20">
+
       {/* --- Hero Section --- */}
       <section className="relative overflow-hidden rounded-3xl bg-blue-600 px-6 py-16 text-white shadow-2xl md:px-12 md:py-20">
         <div className="relative z-10 max-w-2xl">
@@ -51,6 +55,56 @@ const Home = () => {
           </div>
         </div>
         <div className="absolute -right-20 -top-20 h-80 w-80 rounded-full bg-blue-500/30 blur-3xl" />
+      </section>
+
+      {/* 음악 플레이바 섹션 */}
+      <section className="relative -mt-10 z-20 px-4 md:px-10"> 
+        <div className="mx-auto max-w-6xl rounded-full bg-white/70 p-3 shadow-xl backdrop-blur-md border border-white/20 flex items-center justify-between gap-8">    
+        {/* 재생 컨트롤 & 곡 정보 */}
+          <div className="flex items-center gap-3 pl-2">
+            <button 
+              onClick={() => setIsPlaying(!isPlaying)}
+              className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700 transition-all active:scale-95">
+              {isPlaying ? "Ⅱ" : "▶"}
+            </button>
+            <div className="hidden sm:block leading-none">
+              <p className="text-sm font-black text-gray-900 tracking-tight">Idea to Reality</p>
+              <p className="mt-1 text-[11px] text-gray-500 font-medium tracking-tight">Leets 7th FE Track • Playing Now</p>
+            </div>
+          </div>
+
+        {/* 가짜 프로그레스 바 */}
+          <div className="flex-1 px-4 hidden md:flex items-center gap-4">
+            <span className="text-[11px] font-bold text-gray-400">01:45</span>
+            <div className="h-1 flex-1 rounded-full bg-gray-200/50 overflow-hidden">
+              <div className="h-full w-1/3 bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.5)" />
+            </div>
+            <span className="text-[11px] font-bold text-gray-400">03:20</span>
+          </div>
+
+          <div className="flex items-center gap-5 pr-4 border-l border-gray-200/50 pl-6">
+        {/* 볼륨 아이콘 */}
+            <div className="text-gray-400 hover:text-gray-600 cursor-pointer transition-colors">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+              </svg>
+            </div>
+
+        {/* 날씨 정보 */}
+            <div className="flex items-center gap-3 border-l border-gray-200/50 pl-5 min-w-fit">
+              <div className="text-right hidden sm:block leading-none">
+                <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">Seoul</p>
+                <p className="mt-1 text-base font-black text-gray-800">18°C</p>
+              </div>
+              <div className="text-yellow-500">
+                <svg fill="currentColor" viewBox="0 0 20 20" className="h-7 w-7">
+                  <path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707zM18 10a1 1 0 01-1 1h-1a1 1 0 110-2h1a1 1 0 011 1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zM5 10a1 1 0 01-1 1H3a1 1 0 110-2h1a1 1 0 011 1zM8 16v-1h4v1a2 2 0 11-4 0zM12 14c.015-.34.208-.646.477-.859a4 4 0 10-4.954 0c.27.213.462.519.477.859h4z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+        
+        </div>  
       </section>
 
       {/* --- Post Section --- */}
@@ -81,7 +135,7 @@ const Home = () => {
         </div>
       </section>
 
-      {/* --- 상호작용 컴포넌트들 (화면 어디서든 뜰 수 있게 배치) --- */}
+      {/* --- 상호작용 컴포넌트들 --- */}
       <Modal 
         isOpen={isModalOpen} 
         onClose={() => setIsModalOpen(false)} 

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,0 +1,14 @@
+// src/router/Router.tsx
+import { createBrowserRouter } from 'react-router-dom'; 
+import { Layout } from '@/components/layout/Layout';
+import Home from '@/pages/Home';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />, 
+    children: [
+      { index: true, element: <Home /> },
+    ],
+  },
+]);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,12 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    // 경로 별칭 설정
+    "baseUrl": ".", 
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite' // 불러오기 추가
+import tailwindcss from '@tailwindcss/vite'
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
-    tailwindcss(), //  플러그인 등록
+    tailwindcss(), 
+    tsconfigPaths()
   ],
 })


### PR DESCRIPTION
1. 구현한 내용

- [재사용 가능한 공통 컴포넌트 7종 구현 (Button, Input, Header, Modal, Toast, Avatar, Skeleton)
- 메인 페이지(Home) 레이아웃 PC/모바일 반응형 구현(Tailwind Grid 활용)
- 컴포넌트 간 상호작용(Hover, Click, Modal open, Toast) UI 로직 작성
- 권장 추가 구현 반영 (이미지 Lazy Loading, Layout Shift 방지, 글래스모피즘 디자인 적용)

2. 핵심 변경 사항

- src/components/common: Button, Input, Modal, Toast 등 원자 단위의 공통 컴포넌트 라이브러리 구축
- src/components/layout/Header.tsx: 애니메이션이 적용된 검색바와 반응형 내비게이션 구현
- src/pages/Home.tsx: 히어로 섹션 하단에 음악 플레이바(Music Player) 및 날씨 위젯 추가
- Tailwind Grid를 활용한 1/2/3열 반응형 게시글 그리드 시스템 구축
- src/components/domain/PostCard.tsx: 데이터 의존적인 로직을 별도 도메인 컴포넌트로 분리하여 유지보수성 강화

3. 실행 및 검증 결과
<img width="1261" height="671" alt="image" src="https://github.com/user-attachments/assets/235438b9-29f2-4a52-a607-7e15d05ed58c" />
<img width="875" height="620" alt="image" src="https://github.com/user-attachments/assets/fc88c316-9299-47b8-9c8c-dc0b8785d28b" />

4. 완료 사항

- 컴포넌트 계층화: common(범용)과 domain(데이터 의존) 컴포넌트의 명확한 분리
- 반응형 디자인: Mobile(1열), Tablet(2열), Desktop(3열)에 최적화된 그리드 시스템 구축
- 상태 기반 UI: useState를 활용한 모달, 토스트, 음악 재생 버튼의 인터랙션 구현


5. 추가 사항
closed #13 